### PR TITLE
Feature/search dates

### DIFF
--- a/src/app/components/general/CalendarPicker.vue
+++ b/src/app/components/general/CalendarPicker.vue
@@ -1,0 +1,318 @@
+<template>
+    <div class="calendar" :class="classes" :style="actStyles">
+        <template v-if="template === 'month'">
+            <header>
+                <button class="month-selector" @click="template = 'year'">
+                    {{ rangeDate.monthLong }}, {{ rangeDate.year }}
+                </button>
+                <button class="arrow" @click="moveMonth(-1)">
+                    <Icon>arrow_upward_alt</Icon>
+                </button>
+                <button class="arrow" @click="moveMonth(1)">
+                    <Icon>arrow_downward_alt</Icon>
+                </button>
+            </header>
+            <div class="seven-days">
+                <div
+                    class="day header"
+                    v-for="item in selectorRange.iterations[0]?.iterations ?? []"
+                    :key="item.key"
+                >
+                    {{ item.date.weekdayShort }}
+                </div>
+            </div>
+            <div
+                class="seven-days"
+                v-for="item in selectorRange.iterations"
+                :key="item.start.toISODate()!"
+            >
+                <button
+                    class="day"
+                    :class="{
+                        'diff-month': !day.sameMonth,
+                        'today': day.isToday,
+                        'selected': day.isDate,
+                        'in-range': day.inRange
+                    }"
+                    v-for="day in item.iterations"
+                    :key="day.key"
+                    @click="() => date = day.date"
+                    :disabled="!day.inRange"
+                >
+                    {{ day.date.day }}
+                </button>
+            </div>
+        </template>
+        <template v-else-if="template === 'year'">
+            <header>
+                <button class="month-selector" @click="template = 'month'">
+                    {{ rangeDate.year }}
+                </button>
+                <button class="arrow" @click="moveMonth(-12)">
+                    <Icon>arrow_upward_alt</Icon>
+                </button>
+                <button class="arrow" @click="moveMonth(12)">
+                    <Icon>arrow_downward_alt</Icon>
+                </button>
+            </header>
+            <div
+                class="seven-days"
+                v-for="(row, index) in yearRange"
+                :key="index"
+            >
+                <button
+                    class="day"
+                    :class="{
+                        'today': day.isToday,
+                        'selected': day.isSelected,
+                        'in-range': day.inRange
+                    }"
+                    v-for="day in row"
+                    :key="day.date.toISODate()!"
+                    @click="() => { _rangeDate = day.date; template = 'month'; }"
+                    :disabled="!day.inRange"
+                >
+                    {{ day.date.monthShort }}
+                </button>
+            </div>
+        </template>
+        <footer>
+            <button class="selector" @click="_rangeDate = date">
+                {{ date.toFormat('LLLL dd, yyyy') }}
+            </button>
+            <button class="today" @click="today">
+                Today
+            </button>
+        </footer>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { DateTime } from 'luxon';
+import type { ClassOptions, StyleOptions } from '~/models';
+type DateInput = Date | string | DateTime;
+
+const dateUtils = useDateUtils();
+const { serStyles, serClasses, chunk } = useUtils();
+
+const THEME = {
+    color: '#c4c0d8',
+    colorDisabled: '#5c5870',
+    colorSelected: '#61ffca',
+    colorBackground: '#282738',
+    colorBackgroundDark: '#21202e',
+    size: '1.5em',
+    margin: '1rem',
+    padding: '0.25em',
+    fontSize: '1rem'
+} as const;
+
+type Theme = {
+    [key in keyof typeof THEME]: string;
+};
+
+const props = defineProps<{
+    modelValue: DateInput;
+    rangeMin?: DateInput;
+    rangeMax?: DateInput;
+    'class'?: ClassOptions;
+    'styles'?: StyleOptions;
+    theme?: Partial<Theme>;
+}>();
+
+const emits = defineEmits<{
+    (e: 'update:modelValue', value: Date): void;
+}>();
+
+const date = computed({
+    get: () => {
+        const date = dateUtils.ensureDate(props.modelValue);
+        return dateUtils.clamp(date, props.rangeMin, props.rangeMax);
+    },
+    set: (value: DateInput) => {
+        const date = dateUtils.ensureDate(value);
+        const clampedDate = dateUtils.clamp(date, props.rangeMin, props.rangeMax);
+        emits('update:modelValue', clampedDate.toJSDate());
+    }
+});
+
+const _rangeDate = ref<DateTime>();
+const template = ref<'month' | 'year'>('month');
+
+const rangeDate = computed(() => _rangeDate.value ?? date.value);
+
+const monthStart = computed(() => dateUtils.startOf.month(rangeDate.value));
+const monthEnd = computed(() => dateUtils.endOf.month(rangeDate.value));
+const monthMiddle = computed(() => dateUtils.middleOf.month(rangeDate.value));
+const classes = computed(() => serClasses(props.class));
+const actStyles = computed(() => serStyles(props.styles, {
+    '--dts-color': props.theme?.color ?? THEME.color,
+    '--dts-color-disabled': props.theme?.colorDisabled ?? THEME.colorDisabled,
+    '--dts-color-selected': props.theme?.colorSelected ?? THEME.colorSelected,
+    '--dts-color-background': props.theme?.colorBackground ?? THEME.colorBackground,
+    '--dts-color-background-dark': props.theme?.colorBackgroundDark ?? THEME.colorBackgroundDark,
+    '--dts-size': props.theme?.size ?? THEME.size,
+    '--dts-margin': props.theme?.margin ?? THEME.margin,
+    '--dts-padding': props.theme?.padding ?? THEME.padding,
+    '--dts-font-size': props.theme?.fontSize ?? THEME.fontSize,
+}));
+
+const selectorRange = computed(() => {
+    const startMonth = dateUtils.startOf.week(monthStart.value);
+    const endMonth = dateUtils.endOf.week(monthEnd.value);
+
+    const iterations = dateUtils.enumerate(startMonth, endMonth, 'week').map(t => {
+        const start = dateUtils.startOf.week(t);
+        const end = dateUtils.endOf.week(t);
+        const iterations = dateUtils.enumerate(start, end, 'day').map(d => {
+            return {
+                key: d.toISODate()!,
+                date: d,
+                sameMonth: d.month === rangeDate.value.month,
+                isToday: d.hasSame(DateTime.now(), 'day'),
+                isDate: d.hasSame(date.value, 'day'),
+                inRange: (!props.rangeMin || d >= dateUtils.ensureDate(props.rangeMin)) &&
+                    (!props.rangeMax || d <= dateUtils.ensureDate(props.rangeMax))
+            }
+        });
+        return { start, end, iterations };
+    });
+
+    return {
+        start: startMonth,
+        end: endMonth,
+        iterations
+    }
+});
+
+const yearRange = computed(() => {
+    const startYear = dateUtils.startOf.year(rangeDate.value);
+    const endYear = dateUtils.endOf.year(rangeDate.value);
+
+    const months = dateUtils
+        .enumerate(startYear, endYear, 'month')
+        .map(t => {
+            const start = dateUtils.startOf.month(t);
+            const end = dateUtils.endOf.month(t);
+            const middle = dateUtils.middleOf.month(t);
+
+            return {
+                start,
+                end,
+                date: middle,
+                sameMonth: t.month === rangeDate.value.month,
+                isToday: middle.hasSame(DateTime.now(), 'day'),
+                inRange: (!props.rangeMin || end >= dateUtils.ensureDate(props.rangeMin)) &&
+                    (!props.rangeMax || start <= dateUtils.ensureDate(props.rangeMax)),
+                isSelected: date.value >= start && date.value <= end
+            }
+        });
+    return chunk(months, 3);
+});
+
+const moveMonth = (step: number) => {
+    _rangeDate.value = monthMiddle.value.plus({ month: step });
+}
+
+const today = () => {
+    _rangeDate.value = date.value = DateTime.now();
+    template.value = 'month';
+}
+
+</script>
+
+<style lang="scss" scoped>
+$color: var(--dts-color);
+$color-disabled: var(--dts-color-disabled);
+$color-selected: var(--dts-color-selected);
+$color-background: var(--dts-color-background);
+$color-background-dark: var(--dts-color-background-dark);
+$size: var(--dts-size);
+$margin: var(--dts-margin);
+$padding: var(--dts-padding);
+$font-size: var(--dts-font-size);
+
+.calendar {
+    display: flex;
+    flex-flow: column;
+    margin: auto;
+    color: $color;
+    background-color: $color-background;
+    border-radius: 5px;
+    font-size: $font-size;
+    width: 315px;
+
+    button {
+        font-size: $font-size;
+        border: none;
+        background: none;
+        padding: $padding;
+        margin: $padding;
+
+        &:hover {
+            cursor: pointer;
+            background-color: $color-background-dark;
+        }
+
+        &:disabled {
+            cursor: not-allowed;
+            color: $color-disabled;
+        }
+    }
+
+    header, footer {
+        display: flex;
+        flex-flow: row;
+        background-color: $color-background-dark;
+        color: $color-selected;
+        padding: 0 $margin;
+
+        .month-selector {
+            font-weight: bold;
+            flex: 1;
+            text-align: left;
+        }
+
+        .arrow {
+            padding-top: $padding;
+        }
+
+        .selector {
+            flex: 1;
+            text-align: left;
+        }
+    }
+
+    .seven-days {
+        display: flex;
+        flex-flow: row;
+        padding: 0 #{$margin};
+
+        .day {
+            width: $size;
+            height: $size;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: $padding;
+            margin: $padding;
+            flex: 1;
+            text-align: center;
+
+            &.diff-month { color: $color-disabled; }
+            &.today { text-decoration: underline; }
+            &.header { font-weight: bold; }
+
+            &.selected {
+                color: $color-selected;
+                background-color: $color-background-dark;
+            }
+
+            &:disabled {
+                color: $color-disabled;
+                cursor: not-allowed;
+            }
+        }
+    }
+}
+</style>

--- a/src/app/components/manga/DateFilter.vue
+++ b/src/app/components/manga/DateFilter.vue
@@ -1,0 +1,90 @@
+<template>
+    <div class="date-filter flex row">
+        <div class="flex">
+            <CheckBox
+                v-model="useDate"
+            />
+            <label class="center-vert fill">{{ message }}</label>
+            <div 
+                class="center-vert margin-right" 
+                v-if="beforeDate && afterDate"
+            >
+                (&nbsp;
+                <Date :date="beforeDate" format="D" class="mute" />
+                &nbsp;-&nbsp; 
+                <Date :date="afterDate" format="D" class="mute" />
+                &nbsp;)
+            </div>
+        </div>
+        <div class="flex" v-if="beforeDate && afterDate">
+            <CalendarPicker
+                v-model="afterDate"
+                :range-min="min"
+                :range-max="beforeDate"
+            />
+
+            <div class="fill">
+                <label class="center-vert fill">to</label>
+            </div>
+
+            <CalendarPicker
+                v-model="beforeDate"
+                :range-min="afterDate"
+                :range-max="max"
+            />
+        </div>
+    </div>
+</template>
+
+<script lang="ts" setup>
+const dateUtils = useDateUtils();
+
+const props = defineProps<{
+    before?: Date | string;
+    after?: Date | string;
+    message: string;
+    min?: Date | string;
+    max?: Date | string;
+}>();
+
+const emit = defineEmits<{
+    (e: 'update:before', value: string | undefined): void;
+    (e: 'update:after', value: string | undefined): void;
+}>();
+
+const useDate = computed({
+    get: () => !!props.before || !!props.after,
+    set: (value) => {
+        if (!value) {
+            emit('update:before', undefined);
+            emit('update:after', undefined);
+            return;
+        }
+
+        const now = new Date();
+        const date = dateUtils.clamp(props.before ?? props.after ?? now, props.min, props.max)?.toJSDate();
+        beforeDate.value = date;
+        afterDate.value = date;
+    }
+});
+
+const beforeDate = computed({
+    get: () => props.before,
+    set: (value: string | Date | undefined) => {
+        const date = value instanceof Date ? value.toISOString() : value;
+        emit('update:before', date);
+    }
+});
+
+const afterDate = computed({
+    get: () => props.after,
+    set: (value: string | Date | undefined) => {
+        const date = value instanceof Date ? value.toISOString() : value;
+        emit('update:after', date);
+    }
+});
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/src/app/components/manga/DateFilter.vue
+++ b/src/app/components/manga/DateFilter.vue
@@ -5,33 +5,33 @@
                 v-model="useDate"
             />
             <label class="center-vert fill">{{ message }}</label>
-            <div 
-                class="center-vert margin-right" 
+            <div
+                class="center-vert margin-right shown-date"
                 v-if="beforeDate && afterDate"
             >
                 (&nbsp;
                 <Date :date="beforeDate" format="D" class="mute" />
-                &nbsp;-&nbsp; 
+                &nbsp;-&nbsp;
                 <Date :date="afterDate" format="D" class="mute" />
                 &nbsp;)
             </div>
         </div>
-        <div class="flex" v-if="beforeDate && afterDate">
-            <CalendarPicker
-                v-model="afterDate"
-                :range-min="min"
-                :range-max="beforeDate"
-            />
-
-            <div class="fill">
-                <label class="center-vert fill">to</label>
+        <div class="flex calendar-selector margin-top" v-if="beforeDate && afterDate">
+            <div class="center picker">
+                <CalendarPicker
+                    v-model="afterDate"
+                    :range-min="min"
+                    :range-max="beforeDate"
+                />
             </div>
-
-            <CalendarPicker
-                v-model="beforeDate"
-                :range-min="afterDate"
-                :range-max="max"
-            />
+            <p class="center between">Between</p>
+            <div class="center picker">
+                <CalendarPicker
+                    v-model="beforeDate"
+                    :range-min="afterDate"
+                    :range-max="max"
+                />
+            </div>
         </div>
     </div>
 </template>
@@ -87,4 +87,18 @@ const afterDate = computed({
 
 <style lang="scss" scoped>
 
+@media screen and (max-width: 820px) {
+    .shown-date {
+        display: none;
+    }
+
+    .calendar-selector {
+        flex-direction: column;
+        align-items: center;
+
+        .between {
+            margin: 0.5rem 0;
+        }
+    }
+}
 </style>

--- a/src/app/components/manga/MangaSearch.vue
+++ b/src/app/components/manga/MangaSearch.vue
@@ -65,9 +65,38 @@
                 </div>
             </Drawer>
 
+            <Drawer title="Date Filters" storage-key="manga-filter-mdates" default-closed>
+                <DateFilter
+                    v-model:before="searchFilters.mBefore"
+                    v-model:after="searchFilters.mAfter"
+                    message="Manga Added Between:"
+                    :max="new Date()"
+                    :min="APPLICATION_START_DATE"
+                />
+                <DateFilter
+                    v-model:before="searchFilters.cFirstBefore"
+                    v-model:after="searchFilters.cFirstAfter"
+                    message="First Chapter Added Between:"
+                    :max="new Date()"
+                    :min="APPLICATION_START_DATE"
+                />
+                <DateFilter
+                    v-model:before="searchFilters.cLastBefore"
+                    v-model:after="searchFilters.cLastAfter"
+                    message="Latest Chapter Added Between:"
+                    :max="new Date()"
+                    :min="APPLICATION_START_DATE"
+                />
+            </Drawer>
+
             <div class="flex row margin-top margin-bottom">
                 <label>Minimum Chapter Count:</label>
                 <input type="number" v-model="searchFilters.chapMin" />
+            </div>
+
+            <div class="flex row margin-top margin-bottom">
+                <label>Maximum Chapter Count:</label>
+                <input type="number" v-model="searchFilters.chapMax" />
             </div>
 
             <label>Manga Sources:</label>
@@ -105,7 +134,7 @@
 
 <script setup lang="ts">
 import type { LocationQueryValue } from 'vue-router';
-import { MangaOrderBy, STATE_ROLLUP } from '~/models';
+import { MangaOrderBy, STATE_ROLLUP, APPLICATION_START_DATE } from '~/models';
 import type { booleanish, MangaSearchFilter, StateRollup } from '~/models';
 
 const api = useMangaApi();

--- a/src/app/components/manga/MangaSearch.vue
+++ b/src/app/components/manga/MangaSearch.vue
@@ -255,6 +255,14 @@ function parseFilters(): MangaSearchFilter {
         return <any>values;
     }
 
+    const getDate = (value: LocationQueryValue | LocationQueryValue[]): Date | undefined => {
+        const str = Array.isArray(value) ? value[0]?.toString() : value?.toString();
+        if (!str) return undefined;
+
+        const date = new Date(str);
+        return isNaN(date.getTime()) ? undefined : date;
+    };
+
     const filter = {...defaultFilters.value};
 
     const pars: {
@@ -277,7 +285,14 @@ function parseFilters(): MangaSearchFilter {
         'states': { prop: 'states', massage: (v) => getArray(v, t => +t) },
         'statesinclude': { prop: 'statesInclude', massage: (v) => v?.toString().toLocaleLowerCase() === 'true' },
         'statesand': { prop: 'statesAnd', massage: (v) => v?.toString().toLocaleLowerCase() === 'true' },
-        'chapmin': { prop: 'chapMin', massage: (v) => +(v ?? 0) }
+        'chapmin': { prop: 'chapMin', massage: (v) => +(v ?? 0) },
+        'chapmax': { prop: 'chapMax', massage: (v) => +(v ?? 0) },
+        'mbefore': { prop: 'mBefore', massage: getDate },
+        'mafter': { prop: 'mAfter', massage: getDate },
+        'cfirstbefore': { prop: 'cFirstBefore', massage: getDate },
+        'cfirstafter': { prop: 'cFirstAfter', massage: getDate },
+        'clastbefore': { prop: 'cLastBefore', massage: getDate },
+        'clastafter': { prop: 'cLastAfter', massage: getDate }
     };
 
     for(const key in route.query) {

--- a/src/app/components/manga/MangaSearch.vue
+++ b/src/app/components/manga/MangaSearch.vue
@@ -64,9 +64,38 @@
                 </div>
             </Drawer>
 
+            <Drawer title="Date Filters" storage-key="manga-filter-mdates" default-closed>
+                <DateFilter
+                    v-model:before="searchFilters.mBefore"
+                    v-model:after="searchFilters.mAfter"
+                    message="Manga Added Between:"
+                    :max="new Date()"
+                    :min="APPLICATION_START_DATE"
+                />
+                <DateFilter
+                    v-model:before="searchFilters.cFirstBefore"
+                    v-model:after="searchFilters.cFirstAfter"
+                    message="First Chapter Added Between:"
+                    :max="new Date()"
+                    :min="APPLICATION_START_DATE"
+                />
+                <DateFilter
+                    v-model:before="searchFilters.cLastBefore"
+                    v-model:after="searchFilters.cLastAfter"
+                    message="Latest Chapter Added Between:"
+                    :max="new Date()"
+                    :min="APPLICATION_START_DATE"
+                />
+            </Drawer>
+
             <div class="flex row margin-top margin-bottom">
                 <label>Minimum Chapter Count:</label>
                 <input type="number" v-model="searchFilters.chapMin" />
+            </div>
+
+            <div class="flex row margin-top margin-bottom">
+                <label>Maximum Chapter Count:</label>
+                <input type="number" v-model="searchFilters.chapMax" />
             </div>
 
             <label>Manga Sources:</label>
@@ -104,7 +133,7 @@
 
 <script setup lang="ts">
 import type { LocationQueryValue } from 'vue-router';
-import { MangaOrderBy, STATE_ROLLUP } from '~/models';
+import { MangaOrderBy, STATE_ROLLUP, APPLICATION_START_DATE } from '~/models';
 import type { booleanish, MangaSearchFilter, StateRollup } from '~/models';
 
 const api = useMangaApi();

--- a/src/app/components/manga/SearchList.vue
+++ b/src/app/components/manga/SearchList.vue
@@ -62,7 +62,7 @@
             </div>
         </div>
 
-        <div class="pager-wrapper margin-bottom" v-if="canPaginate && !pending">
+        <div class="pager-wrapper margin-bottom" v-if="canPaginate  && (pagination?.total ?? 0) > 1 && !pending">
             <Pager
                 :page="pagination!.page"
                 :pages="pagination!.pages"

--- a/src/app/composables/date-utils.ts
+++ b/src/app/composables/date-utils.ts
@@ -1,0 +1,78 @@
+import { DateTime, type StartOfOptions } from "luxon";
+
+type DateInput = Date | string | DateTime;
+
+export function useDateUtils() {
+
+    const opts: StartOfOptions = {
+        useLocaleWeeks: true
+    };
+
+    const ensureDate = (date: DateInput): DateTime => {
+        if (date instanceof Date) return DateTime.fromJSDate(date);
+        if (typeof date === 'string') return DateTime.fromISO(date);
+        return date;
+    }
+
+    const enumerate = (start: DateInput, end: DateInput | number, step: 'hour' | 'day' | 'week' | 'month' | 'year') => {
+        start = ensureDate(start);
+        end = typeof end === 'number'
+            ? start.plus({ [step]: end })
+            : ensureDate(end);
+        const result: DateTime[] = [];
+        let current = start;
+
+        while (current <= end) {
+            result.push(current);
+            current = current.plus({ [step]: 1 });
+        }
+
+        return result;
+    }
+
+    const middleOf = (date: DateInput, step: 'hour' | 'day' | 'week' | 'month' | 'year') => {
+        date = ensureDate(date);
+        const start = date.startOf(step, opts);
+        const end = date.endOf(step, opts);
+        return start.plus({ milliseconds: (end.toMillis() - start.toMillis()) / 2 });
+    }
+
+    const clamp = (date: DateInput, min?: DateInput, max?: DateInput) => {
+        if (!min && !max) return ensureDate(date);
+
+        date = ensureDate(date);
+        min = min ? ensureDate(min) : undefined;
+        max = max ? ensureDate(max) : undefined;
+
+        if (min && date < min) return min;
+        if (max && date > max) return max;
+        return date;
+    }
+
+    return {
+        ensureDate,
+        enumerate,
+        clamp,
+        middleOf: {
+            hour: (date: DateInput) => middleOf(date, 'hour'),
+            day: (date: DateInput) => middleOf(date, 'day'),
+            week: (date: DateInput) => middleOf(date, 'week'),
+            month: (date: DateInput) => middleOf(date, 'month'),
+            year: (date: DateInput) => middleOf(date, 'year'),
+        },
+        startOf: {
+            hour: (date: DateInput) => ensureDate(date).startOf('hour', opts),
+            day: (date: DateInput) => ensureDate(date).startOf('day', opts),
+            week: (date: DateInput) => ensureDate(date).startOf('week', opts),
+            month: (date: DateInput) => ensureDate(date).startOf('month', opts),
+            year: (date: DateInput) => ensureDate(date).startOf('year', opts),
+        },
+        endOf: {
+            hour: (date: DateInput) => ensureDate(date).endOf('hour', opts),
+            day: (date: DateInput) => ensureDate(date).endOf('day', opts),
+            week: (date: DateInput) => ensureDate(date).endOf('week', opts),
+            month: (date: DateInput) => ensureDate(date).endOf('month', opts),
+            year: (date: DateInput) => ensureDate(date).endOf('year', opts),
+        }
+    }
+}

--- a/src/app/composables/utility-helper.ts
+++ b/src/app/composables/utility-helper.ts
@@ -571,6 +571,18 @@ export const useUtils = () => {
         return Math.min(Math.max(num, min), max);
     }
 
+    /**
+     * Splits the given array into chunks of the given size
+     * @param arr The array to split into chunks
+     * @param size The size of each chunk
+     * @returns The array split into chunks
+     */
+    const chunk = <T>(arr: T[], size: number) => {
+        return Array.from({ length: Math.ceil(arr.length / size) }, (_, i) =>
+            arr.slice(i * size, i * size + size)
+        );
+    }
+
     (() => {
         const doResize = () => {
             if (window && 'resize-watcher' in window) return;
@@ -629,6 +641,7 @@ export const useUtils = () => {
         writeToClipboard,
         baseUrl,
         clamp,
+        chunk,
         parallelForEach: parallelForEachAsync,
         parallelForEachVoid: parallelForEachVoidAsync,
     }

--- a/src/app/models/api/db.ts
+++ b/src/app/models/api/db.ts
@@ -1,5 +1,7 @@
 import type { MbDbObject, MbDbObjectLegacy } from './base';
 
+export const APPLICATION_START_DATE = new Date(2022, 0, 1);
+
 /** Indicates that a user advisory is recommended */
 export enum ContentRating {
     /** No advisory is necessary */


### PR DESCRIPTION
This pull request introduces a reusable date picker and date filter system for the manga search UI, enabling users to filter manga and chapters by date ranges with a modern calendar picker. It also adds utility functions for date handling and array chunking, and improves pagination display logic.

**New Date Filtering UI and Components:**

* Added a reusable `CalendarPicker` component, providing a styled and themeable calendar date picker with month/year navigation, range limiting, and today selection. (`src/app/components/general/CalendarPicker.vue`)
* Introduced a `DateFilter` component for selecting before/after date ranges, supporting two-way binding and integration with the new calendar picker. (`src/app/components/manga/DateFilter.vue`)
* Integrated date filter drawers into the manga search UI, allowing filtering by manga added date, first chapter date, and latest chapter date. (`src/app/components/manga/MangaSearch.vue`) [[1]](diffhunk://#diff-93e4cbefb84bbea02f909f2fe590c6c3b37c044d134453379938dc7ba9613cf6R67-R100) [[2]](diffhunk://#diff-93e4cbefb84bbea02f909f2fe590c6c3b37c044d134453379938dc7ba9613cf6L107-R136)

**Date and Utility Functions:**

* Added `useDateUtils` composable for consistent date parsing, clamping, enumeration, and period calculations, leveraging Luxon for robust date handling. (`src/app/composables/date-utils.ts`)
* Added a `chunk` utility function to split arrays into fixed-size groups, used for rendering calendar months in rows. (`src/app/composables/utility-helper.ts`) [[1]](diffhunk://#diff-aac57609b75ec520825cf00da3904af7c7934e2ec47a7aa10b0486d288c983a5R574-R585) [[2]](diffhunk://#diff-aac57609b75ec520825cf00da3904af7c7934e2ec47a7aa10b0486d288c983a5R644)

**Other Improvements:**

* Improved pagination display logic to only show the pager when more than one page exists. (`src/app/components/manga/SearchList.vue`)
* Defined a global `APPLICATION_START_DATE` constant to restrict date filters to valid data ranges. (`src/app/models/api/db.ts`)